### PR TITLE
Member Portal: Open Play Session Signup

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -195,6 +195,13 @@ func registerRoutes(mux *http.ServeMux, database *db.DB) {
 	mux.Handle("/member/reservations/{id}", member.RequireMemberSession(http.HandlerFunc(methodHandler(map[string]http.HandlerFunc{
 		http.MethodDelete: member.HandleMemberReservationCancel,
 	}))))
+	mux.Handle("/member/openplay", member.RequireMemberSession(http.HandlerFunc(methodHandler(map[string]http.HandlerFunc{
+		http.MethodGet: member.HandleMemberOpenPlayList,
+	}))))
+	mux.Handle("/member/openplay/{id}", member.RequireMemberSession(http.HandlerFunc(methodHandler(map[string]http.HandlerFunc{
+		http.MethodPost:   member.HandleMemberOpenPlaySignup,
+		http.MethodDelete: member.HandleMemberOpenPlayCancel,
+	}))))
 	mux.Handle("/member/lessons/pros", member.RequireMemberSession(http.HandlerFunc(methodHandler(map[string]http.HandlerFunc{
 		http.MethodGet: member.HandleListPros,
 	}))))

--- a/internal/api/member/handlers.go
+++ b/internal/api/member/handlers.go
@@ -993,6 +993,17 @@ func HandleMemberOpenPlaySignup(w http.ResponseWriter, r *http.Request) {
 			return apiutil.HandlerError{Status: http.StatusInternalServerError, Message: "Failed to add open play participant", Err: err}
 		}
 
+		updatedSession, err := qtx.GetOpenPlaySession(ctx, dbgen.GetOpenPlaySessionParams{
+			ID:         sessionID,
+			FacilityID: *user.HomeFacilityID,
+		})
+		if err != nil {
+			return apiutil.HandlerError{Status: http.StatusInternalServerError, Message: "Failed to verify open play capacity", Err: err}
+		}
+		if updatedSession.ParticipantCount > maxParticipants {
+			return apiutil.HandlerError{Status: http.StatusConflict, Message: "Session is full"}
+		}
+
 		return nil
 	})
 	if err != nil {

--- a/internal/api/member/handlers.go
+++ b/internal/api/member/handlers.go
@@ -787,6 +787,328 @@ func HandleMemberReservationCancel(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// HandleMemberOpenPlayList renders upcoming open play sessions for members.
+func HandleMemberOpenPlayList(w http.ResponseWriter, r *http.Request) {
+	logger := log.Ctx(r.Context())
+
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	q := loadQueries()
+	if q == nil {
+		logger.Error().Msg("Database queries not initialized")
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	user := authz.UserFromContext(r.Context())
+	if user == nil {
+		http.Redirect(w, r, "/login", http.StatusFound)
+		return
+	}
+	if user.HomeFacilityID == nil {
+		http.Error(w, "Home facility is required", http.StatusForbidden)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), portalQueryTimeout)
+	defer cancel()
+
+	rows, err := q.ListMemberUpcomingOpenPlaySessions(ctx, dbgen.ListMemberUpcomingOpenPlaySessionsParams{
+		FacilityIds:    []int64{*user.HomeFacilityID},
+		ComparisonTime: time.Now(),
+	})
+	if err != nil {
+		logger.Error().Err(err).Int64("facility_id", *user.HomeFacilityID).Msg("Failed to load open play sessions")
+		http.Error(w, "Failed to load open play sessions", http.StatusInternalServerError)
+		return
+	}
+
+	summaries := membertempl.NewOpenPlaySessionSummaries(rows)
+	for i := range summaries {
+		isParticipant, err := q.IsMemberOpenPlayParticipant(ctx, dbgen.IsMemberOpenPlayParticipantParams{
+			SessionID:  summaries[i].ID,
+			FacilityID: *user.HomeFacilityID,
+			UserID:     user.ID,
+		})
+		if err != nil {
+			logger.Error().Err(err).Int64("session_id", summaries[i].ID).Msg("Failed to check open play participation")
+			continue
+		}
+		summaries[i].IsSignedUp = isParticipant > 0
+	}
+
+	component := membertempl.MemberOpenPlaySessions(membertempl.OpenPlayListData{Upcoming: summaries})
+	if !apiutil.RenderHTMLComponent(r.Context(), w, component, nil, "Failed to render open play list", "Failed to render open play sessions") {
+		return
+	}
+}
+
+// HandleMemberOpenPlaySignup handles POST /member/openplay/{id}.
+func HandleMemberOpenPlaySignup(w http.ResponseWriter, r *http.Request) {
+	logger := log.Ctx(r.Context())
+
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	q := loadQueries()
+	database := loadDB()
+	if q == nil || database == nil {
+		logger.Error().Msg("Database queries not initialized")
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	sessionID, err := memberOpenPlaySessionIDFromRequest(r)
+	if err != nil {
+		http.Error(w, "Invalid session ID", http.StatusBadRequest)
+		return
+	}
+
+	user := authz.UserFromContext(r.Context())
+	if user == nil {
+		http.Redirect(w, r, "/login", http.StatusFound)
+		return
+	}
+	if user.HomeFacilityID == nil {
+		http.Error(w, "Home facility is required", http.StatusForbidden)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), portalQueryTimeout)
+	defer cancel()
+
+	maxMemberReservations := int64(0)
+	facility, err := q.GetFacilityByID(ctx, *user.HomeFacilityID)
+	if err != nil {
+		logger.Error().Err(err).Int64("facility_id", *user.HomeFacilityID).Msg("Failed to load facility booking config")
+	} else {
+		maxMemberReservations = facility.MaxMemberReservations
+	}
+
+	var participant dbgen.ReservationParticipant
+	err = database.RunInTx(ctx, func(txdb *appdb.DB) error {
+		qtx := txdb.Queries
+
+		if maxMemberReservations > 0 {
+			activeCount, err := qtx.CountActiveMemberReservations(ctx, dbgen.CountActiveMemberReservationsParams{
+				FacilityID:    *user.HomeFacilityID,
+				PrimaryUserID: sql.NullInt64{Int64: user.ID, Valid: true},
+			})
+			if err != nil {
+				return apiutil.HandlerError{Status: http.StatusInternalServerError, Message: "Failed to check reservation limits", Err: err}
+			}
+			if activeCount >= maxMemberReservations {
+				return reservationLimitError{currentCount: activeCount, limit: maxMemberReservations}
+			}
+		}
+
+		session, err := qtx.GetOpenPlaySession(ctx, dbgen.GetOpenPlaySessionParams{
+			ID:         sessionID,
+			FacilityID: *user.HomeFacilityID,
+		})
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return apiutil.HandlerError{Status: http.StatusNotFound, Message: "Open play session not found", Err: err}
+			}
+			return apiutil.HandlerError{Status: http.StatusInternalServerError, Message: "Failed to fetch open play session", Err: err}
+		}
+		if session.Status != "scheduled" {
+			return apiutil.HandlerError{Status: http.StatusBadRequest, Message: "Open play session is not scheduled"}
+		}
+		if !session.StartTime.After(time.Now()) {
+			return apiutil.HandlerError{Status: http.StatusBadRequest, Message: "Open play session must be in the future"}
+		}
+
+		rule, err := qtx.GetOpenPlayRule(ctx, dbgen.GetOpenPlayRuleParams{
+			ID:         session.OpenPlayRuleID,
+			FacilityID: *user.HomeFacilityID,
+		})
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return apiutil.HandlerError{Status: http.StatusNotFound, Message: "Open play rule not found", Err: err}
+			}
+			return apiutil.HandlerError{Status: http.StatusInternalServerError, Message: "Failed to fetch open play rule", Err: err}
+		}
+		maxParticipants := rule.MaxParticipantsPerCourt * session.CurrentCourtCount
+		if session.ParticipantCount >= maxParticipants {
+			return apiutil.HandlerError{Status: http.StatusConflict, Message: "Session is full"}
+		}
+
+		isParticipant, err := qtx.IsMemberOpenPlayParticipant(ctx, dbgen.IsMemberOpenPlayParticipantParams{
+			SessionID:  sessionID,
+			FacilityID: *user.HomeFacilityID,
+			UserID:     user.ID,
+		})
+		if err != nil {
+			return apiutil.HandlerError{Status: http.StatusInternalServerError, Message: "Failed to check open play participation", Err: err}
+		}
+		if isParticipant > 0 {
+			return apiutil.HandlerError{Status: http.StatusConflict, Message: "Already signed up"}
+		}
+
+		participant, err = qtx.AddOpenPlayParticipant(ctx, dbgen.AddOpenPlayParticipantParams{
+			UserID:         user.ID,
+			FacilityID:     *user.HomeFacilityID,
+			OpenPlayRuleID: sql.NullInt64{Int64: session.OpenPlayRuleID, Valid: true},
+			StartTime:      session.StartTime,
+			EndTime:        session.EndTime,
+		})
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return apiutil.HandlerError{Status: http.StatusNotFound, Message: "Open play reservation not found", Err: err}
+			}
+			return apiutil.HandlerError{Status: http.StatusInternalServerError, Message: "Failed to add open play participant", Err: err}
+		}
+
+		return nil
+	})
+	if err != nil {
+		var limitErr reservationLimitError
+		if errors.As(err, &limitErr) {
+			message := fmt.Sprintf("You have reached the maximum of %d active reservations", limitErr.limit)
+			http.Error(w, message, http.StatusConflict)
+			return
+		}
+		var herr apiutil.HandlerError
+		if errors.As(err, &herr) {
+			if herr.Status == http.StatusInternalServerError {
+				logger.Error().Err(herr.Err).Int64("session_id", sessionID).Msg(herr.Message)
+			}
+			http.Error(w, herr.Message, herr.Status)
+			return
+		}
+		logger.Error().Err(err).Int64("session_id", sessionID).Msg("Failed to sign up for open play")
+		http.Error(w, "Failed to sign up for open play", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("HX-Trigger", "refreshMemberReservations,refreshMemberOpenPlay")
+	if err := apiutil.WriteJSON(w, http.StatusCreated, participant); err != nil {
+		logger.Error().Err(err).Int64("session_id", sessionID).Msg("Failed to write open play signup response")
+		return
+	}
+}
+
+// HandleMemberOpenPlayCancel handles DELETE /member/openplay/{id}.
+func HandleMemberOpenPlayCancel(w http.ResponseWriter, r *http.Request) {
+	logger := log.Ctx(r.Context())
+
+	q := loadQueries()
+	database := loadDB()
+	if q == nil || database == nil {
+		logger.Error().Msg("Database queries not initialized")
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	sessionID, err := memberOpenPlaySessionIDFromRequest(r)
+	if err != nil {
+		http.Error(w, "Invalid session ID", http.StatusBadRequest)
+		return
+	}
+
+	user := authz.UserFromContext(r.Context())
+	if user == nil {
+		http.Redirect(w, r, "/login", http.StatusFound)
+		return
+	}
+	if user.HomeFacilityID == nil {
+		http.Error(w, "Home facility is required", http.StatusForbidden)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), portalQueryTimeout)
+	defer cancel()
+
+	err = database.RunInTx(ctx, func(txdb *appdb.DB) error {
+		qtx := txdb.Queries
+
+		session, err := qtx.GetOpenPlaySession(ctx, dbgen.GetOpenPlaySessionParams{
+			ID:         sessionID,
+			FacilityID: *user.HomeFacilityID,
+		})
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return apiutil.HandlerError{Status: http.StatusNotFound, Message: "Open play session not found", Err: err}
+			}
+			return apiutil.HandlerError{Status: http.StatusInternalServerError, Message: "Failed to fetch open play session", Err: err}
+		}
+		if session.Status != "scheduled" {
+			return apiutil.HandlerError{Status: http.StatusBadRequest, Message: "Open play session is not scheduled"}
+		}
+		now := time.Now()
+		if !session.StartTime.After(now) {
+			return apiutil.HandlerError{Status: http.StatusBadRequest, Message: "Open play session must be in the future"}
+		}
+
+		isParticipant, err := qtx.IsMemberOpenPlayParticipant(ctx, dbgen.IsMemberOpenPlayParticipantParams{
+			SessionID:  sessionID,
+			FacilityID: *user.HomeFacilityID,
+			UserID:     user.ID,
+		})
+		if err != nil {
+			return apiutil.HandlerError{Status: http.StatusInternalServerError, Message: "Failed to check open play participation", Err: err}
+		}
+		if isParticipant == 0 {
+			return apiutil.HandlerError{Status: http.StatusNotFound, Message: "Open play participant not found"}
+		}
+
+		rule, err := qtx.GetOpenPlayRule(ctx, dbgen.GetOpenPlayRuleParams{
+			ID:         session.OpenPlayRuleID,
+			FacilityID: *user.HomeFacilityID,
+		})
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return apiutil.HandlerError{Status: http.StatusNotFound, Message: "Open play rule not found", Err: err}
+			}
+			return apiutil.HandlerError{Status: http.StatusInternalServerError, Message: "Failed to fetch open play rule", Err: err}
+		}
+		if rule.CancellationCutoffMinutes > 0 {
+			cutoff := session.StartTime.Add(-time.Duration(rule.CancellationCutoffMinutes) * time.Minute)
+			if !now.Before(cutoff) {
+				return apiutil.HandlerError{Status: http.StatusConflict, Message: "Cancellation cutoff has passed"}
+			}
+		}
+
+		removed, err := qtx.RemoveOpenPlayParticipant(ctx, dbgen.RemoveOpenPlayParticipantParams{
+			UserID:         user.ID,
+			FacilityID:     *user.HomeFacilityID,
+			OpenPlayRuleID: sql.NullInt64{Int64: session.OpenPlayRuleID, Valid: true},
+			StartTime:      session.StartTime,
+			EndTime:        session.EndTime,
+		})
+		if err != nil {
+			return apiutil.HandlerError{Status: http.StatusInternalServerError, Message: "Failed to cancel open play signup", Err: err}
+		}
+		if removed == 0 {
+			return apiutil.HandlerError{Status: http.StatusNotFound, Message: "Open play participant not found"}
+		}
+
+		return nil
+	})
+	if err != nil {
+		var herr apiutil.HandlerError
+		if errors.As(err, &herr) {
+			if herr.Status == http.StatusInternalServerError {
+				logger.Error().Err(herr.Err).Int64("session_id", sessionID).Msg(herr.Message)
+			}
+			http.Error(w, herr.Message, herr.Status)
+			return
+		}
+		logger.Error().Err(err).Int64("session_id", sessionID).Msg("Failed to cancel open play signup")
+		http.Error(w, "Failed to cancel open play signup", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("HX-Trigger", "refreshMemberReservations,refreshMemberOpenPlay")
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func lookupReservationTypeID(ctx context.Context, q *dbgen.Queries, name string) (int64, error) {
 	resType, err := q.GetReservationTypeByName(ctx, name)
 	if err != nil {
@@ -1210,6 +1532,18 @@ func parseMemberCourtID(r *http.Request) (int64, error) {
 	id, err := strconv.ParseInt(value, 10, 64)
 	if err != nil || id <= 0 {
 		return 0, fmt.Errorf("court_ids must be a positive integer")
+	}
+	return id, nil
+}
+
+func memberOpenPlaySessionIDFromRequest(r *http.Request) (int64, error) {
+	pathID := strings.TrimSpace(r.PathValue("id"))
+	if pathID == "" {
+		return 0, fmt.Errorf("invalid session ID")
+	}
+	id, err := strconv.ParseInt(pathID, 10, 64)
+	if err != nil || id <= 0 {
+		return 0, fmt.Errorf("invalid session ID")
 	}
 	return id, nil
 }

--- a/internal/db/queries/open_play_sessions.sql
+++ b/internal/db/queries/open_play_sessions.sql
@@ -192,6 +192,7 @@ WHERE r.facility_id = @facility_id
   AND r.start_time = @start_time
   AND r.end_time = @end_time
   AND rt.name = 'OPEN_PLAY'
+LIMIT 1
 RETURNING id, reservation_id, user_id, created_at, updated_at;
 
 -- name: IsMemberOpenPlayParticipant :one
@@ -210,6 +211,16 @@ SELECT EXISTS (
       AND rt.name = 'OPEN_PLAY'
       AND rp.user_id = @user_id
 ) AS is_participant;
+
+-- name: CountOpenPlayReservationsForSession :one
+SELECT COUNT(*)
+FROM reservations r
+JOIN reservation_types rt ON rt.id = r.reservation_type_id
+WHERE r.facility_id = @facility_id
+  AND r.open_play_rule_id = @open_play_rule_id
+  AND r.start_time = @start_time
+  AND r.end_time = @end_time
+  AND rt.name = 'OPEN_PLAY';
 
 -- name: RemoveOpenPlayParticipant :execrows
 DELETE FROM reservation_participants

--- a/internal/templates/components/member/openplay.templ
+++ b/internal/templates/components/member/openplay.templ
@@ -1,0 +1,98 @@
+package member
+
+import "fmt"
+
+templ MemberOpenPlaySessions(data OpenPlayListData) {
+	<div
+		id="member-open-play-sessions"
+		class="bg-background rounded-lg shadow-sm border border-border p-6"
+		hx-get="/member/openplay"
+		hx-trigger="refreshMemberOpenPlay from:body"
+		hx-swap="outerHTML">
+		<div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+			<h2 class="text-xl font-bold text-foreground">Open play sessions</h2>
+			<p class="text-sm text-muted-foreground">Sign up for upcoming open play sessions.</p>
+		</div>
+		if len(data.Upcoming) == 0 {
+			<p class="mt-4 text-muted-foreground">No open play sessions available yet.</p>
+		} else {
+			<div class="mt-6 space-y-6">
+				<div>
+					<h3 class="text-lg font-semibold text-foreground">Upcoming</h3>
+					if len(data.Upcoming) == 0 {
+						<p class="mt-2 text-sm text-muted-foreground">No upcoming sessions.</p>
+					} else {
+						<div class="mt-3 space-y-3">
+							for _, session := range data.Upcoming {
+								<div class="rounded-lg border border-border bg-background p-4 shadow-sm flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+									<div class="space-y-1">
+										<p class="text-foreground font-medium">{session.RuleName}</p>
+										<p class="text-sm text-muted-foreground">
+											{session.StartTime.Format("Jan 2, 2006 3:04 PM")} - {session.EndTime.Format("3:04 PM")}
+										</p>
+										<p class="text-sm text-muted-foreground">
+											Signed up: {fmt.Sprintf("%d", session.ParticipantCount)} (min {fmt.Sprintf("%d", session.MinParticipants)})
+										</p>
+										if session.Status != "" {
+											<span class="inline-flex items-center rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
+												{session.Status}
+											</span>
+										}
+									</div>
+									<div class="flex items-center gap-2">
+										if session.IsSignedUp {
+											<button
+												type="button"
+												class="inline-flex items-center rounded-md border border-red-200 bg-red-50 px-3 py-1.5 text-sm font-semibold text-red-700 hover:bg-red-100"
+												hx-delete={fmt.Sprintf("/member/openplay/%d", session.ID)}
+												hx-confirm="Cancel this open play session?"
+												hx-on::response-error="handleMemberOpenPlayError(event)"
+												hx-swap="none">
+												Cancel
+											</button>
+										} else {
+											<button
+												type="button"
+												class="inline-flex items-center rounded-md border border-blue-200 bg-blue-50 px-3 py-1.5 text-sm font-semibold text-blue-700 hover:bg-blue-100"
+												hx-post={fmt.Sprintf("/member/openplay/%d", session.ID)}
+												hx-on::response-error="handleMemberOpenPlayError(event)"
+												hx-swap="none">
+												Sign up
+											</button>
+										}
+									</div>
+								</div>
+							}
+						</div>
+					}
+				</div>
+			</div>
+		}
+		<script>
+			(function () {
+				if (window.handleMemberOpenPlayError) {
+					return;
+				}
+
+				window.handleMemberOpenPlayError = function (event) {
+					if (!event || !event.detail || !event.detail.xhr) {
+						return;
+					}
+					if (event.detail.xhr.status !== 409) {
+						return;
+					}
+					const modal = document.getElementById("modal");
+					if (!modal) {
+						return;
+					}
+					const responseText = event.detail.xhr.responseText || "";
+					if (window.htmx && window.htmx.swap) {
+						window.htmx.swap(modal, responseText, { swapStyle: "innerHTML" });
+						return;
+					}
+					modal.innerHTML = responseText;
+				};
+			})();
+		</script>
+	</div>
+}

--- a/internal/templates/components/member/openplay.templ
+++ b/internal/templates/components/member/openplay.templ
@@ -10,7 +10,7 @@ templ MemberOpenPlaySessions(data OpenPlayListData) {
 		hx-trigger="refreshMemberOpenPlay from:body"
 		hx-swap="outerHTML">
 		<div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-			<h2 class="text-xl font-bold text-foreground">Open play sessions</h2>
+			<h2 class="text-xl font-bold text-foreground">Open Play Sessions</h2>
 			<p class="text-sm text-muted-foreground">Sign up for upcoming open play sessions.</p>
 		</div>
 		if len(data.Upcoming) == 0 {

--- a/internal/templates/components/member/openplay.templ
+++ b/internal/templates/components/member/openplay.templ
@@ -19,52 +19,48 @@ templ MemberOpenPlaySessions(data OpenPlayListData) {
 			<div class="mt-6 space-y-6">
 				<div>
 					<h3 class="text-lg font-semibold text-foreground">Upcoming</h3>
-					if len(data.Upcoming) == 0 {
-						<p class="mt-2 text-sm text-muted-foreground">No upcoming sessions.</p>
-					} else {
-						<div class="mt-3 space-y-3">
-							for _, session := range data.Upcoming {
-								<div class="rounded-lg border border-border bg-background p-4 shadow-sm flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-									<div class="space-y-1">
-										<p class="text-foreground font-medium">{session.RuleName}</p>
-										<p class="text-sm text-muted-foreground">
-											{session.StartTime.Format("Jan 2, 2006 3:04 PM")} - {session.EndTime.Format("3:04 PM")}
-										</p>
-										<p class="text-sm text-muted-foreground">
-											Signed up: {fmt.Sprintf("%d", session.ParticipantCount)} (min {fmt.Sprintf("%d", session.MinParticipants)})
-										</p>
-										if session.Status != "" {
-											<span class="inline-flex items-center rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
-												{session.Status}
-											</span>
-										}
-									</div>
-									<div class="flex items-center gap-2">
-										if session.IsSignedUp {
-											<button
-												type="button"
-												class="inline-flex items-center rounded-md border border-red-200 bg-red-50 px-3 py-1.5 text-sm font-semibold text-red-700 hover:bg-red-100"
-												hx-delete={fmt.Sprintf("/member/openplay/%d", session.ID)}
-												hx-confirm="Cancel this open play session?"
-												hx-on::response-error="handleMemberOpenPlayError(event)"
-												hx-swap="none">
-												Cancel
-											</button>
-										} else {
-											<button
-												type="button"
-												class="inline-flex items-center rounded-md border border-blue-200 bg-blue-50 px-3 py-1.5 text-sm font-semibold text-blue-700 hover:bg-blue-100"
-												hx-post={fmt.Sprintf("/member/openplay/%d", session.ID)}
-												hx-on::response-error="handleMemberOpenPlayError(event)"
-												hx-swap="none">
-												Sign up
-											</button>
-										}
-									</div>
+					<div class="mt-3 space-y-3">
+						for _, session := range data.Upcoming {
+							<div class="rounded-lg border border-border bg-background p-4 shadow-sm flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+								<div class="space-y-1">
+									<p class="text-foreground font-medium">{session.RuleName}</p>
+									<p class="text-sm text-muted-foreground">
+										{session.StartTime.Format("Jan 2, 2006 3:04 PM")} - {session.EndTime.Format("3:04 PM")}
+									</p>
+									<p class="text-sm text-muted-foreground">
+										Signed up: {fmt.Sprintf("%d", session.ParticipantCount)} (min {fmt.Sprintf("%d", session.MinParticipants)})
+									</p>
+									if session.Status != "" {
+										<span class="inline-flex items-center rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
+											{session.Status}
+										</span>
+									}
 								</div>
-							}
-						</div>
-					}
+								<div class="flex items-center gap-2">
+									if session.IsSignedUp {
+										<button
+											type="button"
+											class="inline-flex items-center rounded-md border border-red-200 bg-red-50 px-3 py-1.5 text-sm font-semibold text-red-700 hover:bg-red-100"
+											hx-delete={fmt.Sprintf("/member/openplay/%d", session.ID)}
+											hx-confirm="Cancel this open play session?"
+											hx-on::response-error="handleMemberOpenPlayError(event)"
+											hx-swap="none">
+											Cancel
+										</button>
+									} else {
+										<button
+											type="button"
+											class="inline-flex items-center rounded-md border border-blue-200 bg-blue-50 px-3 py-1.5 text-sm font-semibold text-blue-700 hover:bg-blue-100"
+											hx-post={fmt.Sprintf("/member/openplay/%d", session.ID)}
+											hx-on::response-error="handleMemberOpenPlayError(event)"
+											hx-swap="none">
+											Sign up
+										</button>
+									}
+								</div>
+							</div>
+						}
+					</div>
 				</div>
 			</div>
 		}

--- a/internal/templates/components/member/portal.templ
+++ b/internal/templates/components/member/portal.templ
@@ -36,6 +36,18 @@ templ MemberPortal(profile PortalProfile, reservations ReservationListData) {
 		</div>
 
 		@MemberReservations(reservations)
+		<div
+			id="member-open-play-sessions"
+			class="bg-background rounded-lg shadow-sm border border-border p-6"
+			hx-get="/member/openplay"
+			hx-trigger="load"
+			hx-swap="outerHTML">
+			<div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+				<h2 class="text-xl font-bold text-foreground">Open Play Sessions</h2>
+				<p class="text-sm text-muted-foreground">Sign up for upcoming open play sessions.</p>
+			</div>
+			<p class="mt-4 text-muted-foreground">Loading open play sessions...</p>
+		</div>
 	</div>
 }
 

--- a/internal/templates/components/member/portal.templ
+++ b/internal/templates/components/member/portal.templ
@@ -40,7 +40,7 @@ templ MemberPortal(profile PortalProfile, reservations ReservationListData) {
 			id="member-open-play-sessions"
 			class="bg-background rounded-lg shadow-sm border border-border p-6"
 			hx-get="/member/openplay"
-			hx-trigger="load"
+			hx-trigger="load, refreshMemberOpenPlay from:body"
 			hx-swap="outerHTML">
 			<div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
 				<h2 class="text-xl font-bold text-foreground">Open Play Sessions</h2>

--- a/internal/templates/components/member/types.go
+++ b/internal/templates/components/member/types.go
@@ -91,6 +91,21 @@ type ReservationWidgetData struct {
 	Count    int
 }
 
+type OpenPlaySessionSummary struct {
+	ID               int64
+	RuleName         string
+	StartTime        time.Time
+	EndTime          time.Time
+	Status           string
+	ParticipantCount int64
+	MinParticipants  int64
+	IsSignedUp       bool
+}
+
+type OpenPlayListData struct {
+	Upcoming []OpenPlaySessionSummary
+}
+
 type CancellationPenaltyData struct {
 	ReservationID    int64     `json:"reservation_id"`
 	FeePercentage    int64     `json:"fee_percentage"`
@@ -210,6 +225,26 @@ func NewReservationWidgetData(upcoming []ReservationSummary) ReservationWidgetDa
 		Upcoming: upcoming,
 		Count:    len(upcoming),
 	}
+}
+
+func NewOpenPlaySessionSummary(row dbgen.ListMemberUpcomingOpenPlaySessionsRow) OpenPlaySessionSummary {
+	return OpenPlaySessionSummary{
+		ID:               row.ID,
+		RuleName:         row.RuleName,
+		StartTime:        row.StartTime,
+		EndTime:          row.EndTime,
+		Status:           row.Status,
+		ParticipantCount: row.ParticipantCount,
+		MinParticipants:  row.MinParticipants,
+	}
+}
+
+func NewOpenPlaySessionSummaries(rows []dbgen.ListMemberUpcomingOpenPlaySessionsRow) []OpenPlaySessionSummary {
+	summaries := make([]OpenPlaySessionSummary, len(rows))
+	for i, row := range rows {
+		summaries[i] = NewOpenPlaySessionSummary(row)
+	}
+	return summaries
 }
 
 func (r ReservationWidgetData) BadgeLabel() string {


### PR DESCRIPTION
## Member Portal: Open Play Session Signup

Story: STORY-0031 - Member Portal: Open Play Session Signup

### Summary
9 commit(s) implementing this workstream.

---
*Created by hashd workflow*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Members can now view upcoming Open Play sessions and manage signups directly in the Member Portal.
  * Added Open Play Sessions section displaying session details (rule name, times, participant counts, and status).
  * Signup/cancel functionality with dynamic action buttons based on participation status.
  * Reservation counting now includes Open Play sessions alongside existing reservation types.
  * Updated error messaging when reservation limits are reached.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->